### PR TITLE
Typo edits for session 1

### DIFF
--- a/Day1-Session1-Practical/session1_practical.ipynb
+++ b/Day1-Session1-Practical/session1_practical.ipynb
@@ -826,7 +826,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also see them in the docs [here](https://docs.mdanalysis.org/stable/documentation_pages/selections.html).\n",
+    "You can also see them in the docs [here](https://docs.mdanalysis.org/2.0.0-dev0/documentation_pages/selections.html).\n",
     "\n",
     "Although boolean selections work well enough for selecting out atoms from AtomGroups, the selection language makes more complex selections possible with probably less effort.\n",
     "\n",
@@ -886,7 +886,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can use `and`/`or`/`not` to combine selection terms:"
+    "We can use `and`/`or`/`not` to combine selection terms with [logical conjunctions](https://en.wikipedia.org/wiki/Logical_conjunction):"
    ]
   },
   {
@@ -971,7 +971,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are also serveral preset keywords for useful selections such as `backbone`, which selects all CA, C, O and N atoms:"
+    "There are also several preset keywords for useful selections such as `backbone`, which selects all CA, C, O and N atoms:"
    ]
   },
   {
@@ -1264,7 +1264,7 @@
     "solution2_first": true
    },
    "source": [
-    "**2b. Count the number of argenine residues**"
+    "**2b. Count the number of arginine residues**"
    ]
   },
   {
@@ -1344,7 +1344,7 @@
    "source": [
     "**2d. Select all hydrogens that are bonded to an alpha carbon**\n",
     "\n",
-    "*Hint: Look through the `select_atoms` docstring above or [here](https://docs.mdanalysis.org/stable/documentation_pages/selections.html) for keywords that might help!*"
+    "*Hint: Look through the `select_atoms` docstring above or [here](https://docs.mdanalysis.org/2.0.0-dev0/documentation_pages/selections.html) for keywords that might help!*"
    ]
   },
   {
@@ -1387,7 +1387,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[nglview](https://github.com/nglviewer/nglview#usage) is a package that allows to visualize a MDAnalysis `Universe` or `AtomGroup` directly on the jupyter notebook. First we load structure:"
+    "[nglview](https://github.com/nglviewer/nglview#usage) is a package that allows to visualize a MDAnalysis `Universe` or `AtomGroup` directly on the jupyter notebook. First we load the structure:"
    ]
   },
   {
@@ -1633,7 +1633,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively, we can use the build-in method:"
+    "Alternatively, we can use the built-in method:"
    ]
   },
   {
@@ -1660,7 +1660,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Other conveninet methods for common calculations based on positions include `center_of_mass()`, `radius_of_gyration()` and `principal_axes()`."
+    "Other convenient methods for common calculations based on positions include `center_of_mass()`, `radius_of_gyration()` and `principal_axes()`."
    ]
   },
   {
@@ -1677,7 +1677,7 @@
    },
    "source": [
     "\n",
-    "Lets look in more detail at the AdK protein. AdK has three domains:\n",
+    "Let's look in more detail at the AdK protein. AdK has three domains:\n",
     "\n",
     " - CORE (residues 1-29, 60-121, 160-214)\n",
     " - NMP (residues 30-59)\n",
@@ -2021,7 +2021,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- If you haven't already, read through the [selection documentation](https://docs.mdanalysis.org/stable/documentation_pages/selections.html) and play around with all the selection options not covered above\n",
+    "- If you haven't already, read through the [selection documentation](https://docs.mdanalysis.org/2.0.0-dev0/documentation_pages/selections.html) and play around with all the selection options not covered above\n",
     "\n",
     "\n",
     "- [nglview](https://github.com/nglviewer/nglview#usage) has a lot of options for visualising - you can add multiple selections to one view, change their colour and representation style and more - look through their documentaiton and see what you can create!"
@@ -2052,7 +2052,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.10"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Minor typo edits. The most important change is probably switching all the links for docs from `stable` to `2.0.0-dev0`. This is especially important for selections where they got upgraded somewhat majorly between versions 1 and 2.