### PR TITLE
Adds authors, improves install instructions

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,14 @@
+# List of authors to the workshop materials
+
+Authors are added at each year of contribution and sorted by first name.
+
+## 2021
+
+- Fiona Naughton (@fiona-naughton)
+- Irfan Alibay (@IAlibay)
+- Jonathan Barnoud (@jbarnoud)
+- Lily Wang (@lilyminium)
+- Manuel E Melo (@mnmelo)
+- Micaela Matta (@micaela-matta)
+- Oliver Beckstein (@orbeckst)
+- Richard Gowers (@richardjgowers)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,56 @@
+# Installing the workshop environment
+
+## Overview
+
+This workshop is delivered mainly through a series of [Jupyter notebooks][1]
+that allow for interactive python programming.
+
+To use these, several python packages must be installed. A full list of these
+can be found in [`environment.yml`](environment.yml). See below for
+instructions on how to set up a local copy of the python environment.
+
+**Note: at this time, the workshop requires the beta version of MDAnalysis 2.0.0.**
+
+
+## Installing the python environment
+
+Due to the complexity of the workshop environment, we strongly recommend the
+use of the [anaconda python distribution][2]. Our instructions, provided here,
+assume the use of [conda][3].
+
+### 1. Creating a workshop environment
+
+To create an environment named `mda-workshop2021` with all the necessary
+python dependencies:
+
+```bash
+conda env create --name mda-workshop2021 --file=environments.yml
+```
+
+See the [conda documentation][4] for more information on how to access and
+manage [conda][3] environments.
+
+### 2. Activating the jupyter extensions
+
+The workshop leverages the extended utility of several jupyter nbextensions.
+
+To install these, the followed should be run **once** (after having activated
+the conda environment):
+
+```bash
+jupyter contrib nbextension install --user
+jupyter nbextension enable splitcell/splitcell
+jupyter nbextension enable rubberband/main
+jupyter nbextension enable exercise2/main
+jupyter nbextension enable autosavetime/main
+jupyter nbextension enable collapsible_headings/main
+jupyter nbextension enable codefolding/main
+jupyter nbextension enable limit_output/main
+jupyter nbextension enable toc2/main
+```
+
+
+[1]: https://jupyter-notebook.readthedocs.io/en/stable/
+[2]: https://docs.anaconda.com/anaconda/install/
+[3]: https://conda.io/projects/conda/en/latest/index.html
+[4]: https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html?highlight=conda%20activate#managing-environments

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,25 +3,25 @@
 ## Overview
 
 This workshop is delivered mainly through a series of [Jupyter notebooks][1]
-that allow for interactive python programming.
+that allow for interactive Python programming.
 
-To use these, several python packages must be installed. A full list of these
+To use these, several Python packages must be installed. A full list of these
 can be found in [`environment.yml`](environment.yml). See below for
-instructions on how to set up a local copy of the python environment.
+instructions on how to set up a local copy of the Python environment.
 
 **Note: at this time, the workshop requires the beta version of MDAnalysis 2.0.0.**
 
 
-## Installing the python environment
+## Installing the Python environment
 
 Due to the complexity of the workshop environment, we strongly recommend the
-use of the [anaconda python distribution][2]. Our instructions, provided here,
+use of the [Anaconda Python distribution][2]. The instructions provided here
 assume the use of [conda][3].
 
 ### 1. Creating a workshop environment
 
 To create an environment named `mda-workshop2021` with all the necessary
-python dependencies:
+Python dependencies:
 
 ```bash
 conda env create --name mda-workshop2021 --file=environments.yml
@@ -30,9 +30,9 @@ conda env create --name mda-workshop2021 --file=environments.yml
 See the [conda documentation][4] for more information on how to access and
 manage [conda][3] environments.
 
-### 2. Activating the jupyter extensions
+### 2. Activating the Jupyter extensions
 
-The workshop leverages the extended utility of several jupyter nbextensions.
+The workshop leverages the extended utility of several Jupyter nbextensions.
 
 To install these, the followed should be run **once** (after having activated
 the conda environment):

--- a/README.md
+++ b/README.md
@@ -119,10 +119,13 @@ The workshop is structured in the following manner:
 
 ## Setting up your python environment
 
-Instructions for seting up your environment to run this workshop locally
-are providing in [`INSTALL.md`](INSTALL.md).
+Instructions for setting up your environment to run this workshop locally
 
-A full list of the required python packages can be seen inside [`environment.yml`](environment.yml).
+are provided in [`INSTALL.md`](INSTALL.md).
+
+
+A full list of the required Python packages can be seen inside [`environment.yml`](environment.yml).
+
 
 **Note: this workshop uses the beta release of MDAnalysis 2.0.0.**
 
@@ -130,7 +133,8 @@ A full list of the required python packages can be seen inside [`environment.yml
 ## Course pre-requisites
 
 The course assumes that attendees have a working proficiency in using
-[jupyter notebooks][1], python (especially the [numpy library][2]), and the
+[Jupyter notebooks][1], Python (especially the [NumPy library][2]), and the
+
 bash shell.
 
 
@@ -151,7 +155,8 @@ Unported License.
 
 ## Acknowledgements
 
-Please see [`AUTHORS.md`](AUTHORS.md) for a list contributors to the workshop
+Please see [`AUTHORS.md`](AUTHORS.md) for a list of contributors to the workshop
+
 materials.
 
 Special acknowlegements go to the [2018 MDAnalysis Workshop and Hackathon][3]

--- a/README.md
+++ b/README.md
@@ -117,28 +117,21 @@ The workshop is structured in the following manner:
     SURF / PRACE workshop closing remarks.
 
 
-
 ## Setting up your python environment
 
-In order to access this material, several python packages must be installed. A full
-list can be seen inside `environment.yml`.
+Instructions for seting up your environment to run this workshop locally
+are providing in [`INSTALL.md`](INSTALL.md).
 
-To set up the environment (using conda), the following can be done:
-
-```bash
-conda env create --name envname --file=environments.yml
-jupyter contrib nbextension install --user
-jupyter nbextension enable splitcell/splitcell
-jupyter nbextension enable rubberband/main
-jupyter nbextension enable exercise2/main
-jupyter nbextension enable autosavetime/main
-jupyter nbextension enable collapsible_headings/main
-jupyter nbextension enable codefolding/main
-jupyter nbextension enable limit_output/main
-jupyter nbextension enable toc2/main
-```
+A full list of the required python packages can be seen inside [`environment.yml`](environment.yml).
 
 **Note: this workshop uses the beta release of MDAnalysis 2.0.0.**
+
+
+## Course pre-requisites
+
+The course assumes that attendees have a working proficiency in using
+[jupyter notebooks][1], python (especially the [numpy library][2]), and the
+bash shell.
 
 
 ## Binder
@@ -154,3 +147,17 @@ license. Non-code content is licensed under the Creative Commons
 Attribution-ShareAlike 4.0 International license. The MDAnalysis logo and its
 derivatives are licensed under the Creative Commons Attribution-NoDerivs 3.0
 Unported License.
+
+
+## Acknowledgements
+
+Please see [`AUTHORS.md`](AUTHORS.md) for a list contributors to the workshop
+materials.
+
+Special acknowlegements go to the [2018 MDAnalysis Workshop and Hackathon][3]
+which these materials build on.
+
+
+[1]: https://jupyter-notebook.readthedocs.io/en/stable/
+[2]: https://numpy.org/
+[3]: https://github.com/MDAnalysis/WorkshopHackathon2018


### PR DESCRIPTION
Towards v1.1.0
Fixes #34

Work done in this PR:
* Adds author information
* Separates out the install instructions and fixes the activation of the jupyter nbextensions (old instructions would have had them be activate in `base` rather than a specific conda environment).
